### PR TITLE
Replace shelve with SQLite for mutation database storage

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -90,7 +90,10 @@ Here is a list of the available command-line options:
 
 .. option:: --use-alternate-database <path>
 
-    Path to alternative database.
+    Path to a previously generated mutation database (SQLite). Useful for
+    running the build phase against a database produced by a different
+    mutation run, or pointing external tooling at the relational schema
+    (see ``MutationDatabase`` for the table layout).
 
 .. option:: --license
 

--- a/littledarwin/LittleDarwin.py
+++ b/littledarwin/LittleDarwin.py
@@ -35,7 +35,6 @@ import datetime
 import io
 import os
 import platform
-import shelve
 import shutil
 import signal
 import subprocess
@@ -49,6 +48,7 @@ from .JavaIO import JavaIO
 from .JavaMutate import JavaMutate
 # LittleDarwin modules
 from .JavaParse import JavaParse
+from .MutationDatabase import MutationDatabase
 from .ReportGenerator import ReportGenerator
 
 ### DEBUG ###
@@ -157,7 +157,7 @@ def mutationPhase(options, filterType, filterList, higherOrder):
     print("Source Path: ", javaIO.sourceDirectory)
     print("Target Path: ", javaIO.targetDirectory)
     print("Creating Mutation Database: ", databasePath)
-    mutationDatabase = shelve.open(databasePath, "c")
+    mutationDatabase = MutationDatabase(databasePath, "c")
     mutantTypeDatabase = dict()
     averageDensityDict = dict()
 
@@ -222,7 +222,7 @@ def mutationPhase(options, filterType, filterList, higherOrder):
 
         # if the list is not empty (some mutants were found), put the data in the database.
         if len(targetList) != 0:
-            mutationDatabase[fileRelativePath] = targetList
+            mutationDatabase.set(fileRelativePath, targetList)
 
         del javaMutate
 
@@ -297,7 +297,7 @@ def buildPhase(options):
         separateTestSuite = False
     # try to open the database. if it can't be opened, it means that it does not exist or it is corrupt.
     try:
-        mutationDatabase = shelve.open(databasePath, "r")
+        mutationDatabase = MutationDatabase(databasePath, "r")
     except:
         print(
             "Cannot open mutation database. It may be corrupted or unavailable. Delete all generated files and run the mutant generation phase again.")
@@ -354,7 +354,7 @@ def buildPhase(options):
     totalMutantCount = 0
     totalMutantCounter = 0
     for key in databaseKeys:
-        totalMutantCount += len(mutationDatabase[key])
+        totalMutantCount += len(mutationDatabase.get(key))
     startTime = time.time()
     # running the build system for each mutant.
     for key in databaseKeys:
@@ -363,14 +363,14 @@ def buildPhase(options):
 
         print("(" + str(fileCounter) + "/" + str(mutationDatabaseLength) + ") collecting results for ", key)
 
-        mutantCount = len(mutationDatabase[key])
+        mutantCount = len(mutationDatabase.get(key))
         mutantCounter = 0
 
         successList = list()
         failureList = list()
 
         # for each mutant, replace the original file, run the build, store the results
-        for replacementFileRel in mutationDatabase[key]:
+        for replacementFileRel in mutationDatabase.get(key):
             replacementFile = os.path.abspath(os.path.join(mutantsPath, replacementFileRel))
             mutantCounter += 1
             totalMutantCounter += 1
@@ -481,6 +481,10 @@ def buildPhase(options):
     targetHTMLReportFile = os.path.abspath(os.path.join(mutantsPath, "index.html"))
     with open(targetHTMLReportFile, 'w', encoding="utf-8") as htmlReportFile:
         htmlReportFile.writelines(reportGenerator.generateHTMLFinalReport(htmlReportData, targetHTMLReportFile))
+
+    # close the databases so their files are released (important on Windows before cleanup).
+    mutationDatabase.close()
+    reportGenerator.database.close()
 
 
 def parseCmdArgs(optionParser: OptionParser, mockArgs: list = None) -> object:

--- a/littledarwin/LittleDarwin.py
+++ b/littledarwin/LittleDarwin.py
@@ -123,8 +123,11 @@ def mutationPhase(options, filterType, filterList, higherOrder):
     """
     Performs the mutation phase of LittleDarwin.
 
-    This function finds all the Java files in the source directory,
-    parses them, generates mutants, and stores them in a database.
+    Finds all the Java files in the source directory, parses them, generates
+    mutants on disk, and records each mutant in the relational
+    ``MutationDatabase`` (SQLite). Per-line mutant density and per-method
+    complexity are written to the same database alongside the existing
+    side-car CSV files.
 
     :param options: The command-line options.
     :type options: optparse.Values
@@ -150,21 +153,20 @@ def mutationPhase(options, filterType, filterList, higherOrder):
                      filterType=filterType, filterList=filterList)
     fileCounter = 0
     fileCount = len(javaIO.fileList)
-    # creating a database for generated mutants. the format of this database is different on different platforms,
-    # so it cannot be simply copied from a platform to another.
+    # creating a single SQLite database for the whole run. relational schema (see MutationDatabase),
+    # so it's portable across platforms and queryable with any SQL client.
     databasePath = os.path.join(javaIO.targetDirectory, "mutationdatabase")
     densityResultsPath = os.path.join(javaIO.targetDirectory, "ProjectDensityReport.csv")
     print("Source Path: ", javaIO.sourceDirectory)
     print("Target Path: ", javaIO.targetDirectory)
     print("Creating Mutation Database: ", databasePath)
-    mutationDatabase = MutationDatabase(databasePath, "c")
+    mutationDatabase = MutationDatabase(databasePath, "n")
     mutantTypeDatabase = dict()
     averageDensityDict = dict()
 
     # go through each file, parse it, calculate all mutations, and generate files accordingly.
     for srcFile in javaIO.fileList:
         print("\n(" + str(fileCounter + 1) + "/" + str(fileCount) + ") Source file: ", srcFile)
-        targetList = list()
 
         try:
             # parsing the source file into a tree.
@@ -216,13 +218,20 @@ def mutationPhase(options, filterType, filterList, higherOrder):
                                                                   javaParse.getCyclomaticComplexityAllMethods(tree),
                                                                   javaParse.getLinesOfCodePerMethod(tree))
 
+        mutantIndex = 0
         for mutatedFile in mutated:
-            targetList.append(javaIO.generateNewFile(srcFile, mutatedFile, javaMutate.mutantsPerLine,
-                                                     densityReport, aggregateComplexity))
+            mutantIndex += 1
+            mutantRelPath = javaIO.generateNewFile(srcFile, mutatedFile, javaMutate.mutantsPerLine,
+                                                   densityReport, aggregateComplexity)
+            mutationDatabase.add_mutant(fileRelativePath, mutantIndex, mutantRelPath)
 
-        # if the list is not empty (some mutants were found), put the data in the database.
-        if len(targetList) != 0:
-            mutationDatabase.set(fileRelativePath, targetList)
+        # mirror the per-file density/complexity side-car CSVs into the DB so the SQLite file is
+        # a self-contained artifact of the run.
+        if len(mutated) != 0:
+            mutationDatabase.record_line_densities(fileRelativePath, javaMutate.mutantsPerLine.items())
+            mutationDatabase.record_method_complexities(
+                fileRelativePath,
+                [(name, vals[0], vals[1], vals[2]) for name, vals in aggregateComplexity.items()])
 
         del javaMutate
 
@@ -245,10 +254,11 @@ def buildPhase(options):
     """
     Performs the build phase of LittleDarwin.
 
-    This function iterates through the mutants in the database, and for each
-    mutant, it replaces the original file with the mutant, runs the build
-    command, and records whether the build succeeded or failed. It then
-    generates a report of the results.
+    Iterates through the mutants stored in the relational ``MutationDatabase``
+    and, for each one, replaces the original source file with the mutant,
+    runs the build command, and updates the mutant's ``build_status`` to
+    ``survived`` or ``killed`` directly in the database. Then generates the
+    HTML/text reports of the results.
 
     :param options: The command-line options.
     :type options: optparse.Values
@@ -264,8 +274,6 @@ def buildPhase(options):
         databasePath = options.alternateDb
     mutantsPath = os.path.dirname(databasePath)
     assert os.path.isdir(mutantsPath)
-    resultsDatabasePath = databasePath + "-results"
-    reportGenerator.initiateDatabase(resultsDatabasePath)
     try:
         if os.path.basename(options.buildPath) == "pom.xml":
             assert os.path.isfile(options.buildPath)
@@ -295,14 +303,18 @@ def buildPhase(options):
 
     else:
         separateTestSuite = False
-    # try to open the database. if it can't be opened, it means that it does not exist or it is corrupt.
-    try:
-        mutationDatabase = MutationDatabase(databasePath, "r")
-    except:
+    # open the database read/write so we can record build results. fail loudly if it isn't there.
+    if not os.path.exists(databasePath):
         print(
             "Cannot open mutation database. It may be corrupted or unavailable. Delete all generated files and run the mutant generation phase again.")
         sys.exit(2)
-    databaseKeys = list(mutationDatabase.keys())
+    try:
+        mutationDatabase = MutationDatabase(databasePath, "c")
+    except Exception:
+        print(
+            "Cannot open mutation database. It may be corrupted or unavailable. Delete all generated files and run the mutant generation phase again.")
+        sys.exit(2)
+    databaseKeys = list(mutationDatabase.source_paths())
     assert isinstance(databaseKeys, list)
     # let's sort the mutants by name to create the possibility of following the flow of the process by user.
     databaseKeys.sort()
@@ -354,7 +366,7 @@ def buildPhase(options):
     totalMutantCount = 0
     totalMutantCounter = 0
     for key in databaseKeys:
-        totalMutantCount += len(mutationDatabase.get(key))
+        totalMutantCount += mutationDatabase.mutant_count_for(key)
     startTime = time.time()
     # running the build system for each mutant.
     for key in databaseKeys:
@@ -363,14 +375,15 @@ def buildPhase(options):
 
         print("(" + str(fileCounter) + "/" + str(mutationDatabaseLength) + ") collecting results for ", key)
 
-        mutantCount = len(mutationDatabase.get(key))
+        mutantsForKey = mutationDatabase.mutants_for(key)
+        mutantCount = len(mutantsForKey)
         mutantCounter = 0
 
         successList = list()
         failureList = list()
 
         # for each mutant, replace the original file, run the build, store the results
-        for replacementFileRel in mutationDatabase.get(key):
+        for replacementFileRel in mutantsForKey:
             replacementFile = os.path.abspath(os.path.join(mutantsPath, replacementFileRel))
             mutantCounter += 1
             totalMutantCounter += 1
@@ -419,6 +432,7 @@ def buildPhase(options):
                 # if we are here, it means no exceptions happened, so let's add this to our success list.
                 runOutput = f"{runOutput}\n{runOutputTest}"
                 successList.append(os.path.basename(replacementFile))
+                mutationDatabase.record_result(replacementFileRel, "survived")
 
             # putting two exceptions in one except clause, specially when one of them is not defined on some
             # platforms does not look like a good idea; even though both of them do exactly the same thing.
@@ -426,6 +440,7 @@ def buildPhase(options):
                 runOutput = str(exception.output) if exception.output else ""
                 # oops, error. let's add this to failure list.
                 failureList.append(os.path.basename(replacementFile))
+                mutationDatabase.record_result(replacementFileRel, "killed")
 
             # except subprocess.TimeoutExpired as exception:
             #     runOutput = exception.output
@@ -482,9 +497,8 @@ def buildPhase(options):
     with open(targetHTMLReportFile, 'w', encoding="utf-8") as htmlReportFile:
         htmlReportFile.writelines(reportGenerator.generateHTMLFinalReport(htmlReportData, targetHTMLReportFile))
 
-    # close the databases so their files are released (important on Windows before cleanup).
+    # close the database so its file is released (important on Windows before cleanup).
     mutationDatabase.close()
-    reportGenerator.database.close()
 
 
 def parseCmdArgs(optionParser: OptionParser, mockArgs: list = None) -> object:

--- a/littledarwin/MutationDatabase.py
+++ b/littledarwin/MutationDatabase.py
@@ -1,0 +1,102 @@
+import os
+import pickle
+import sqlite3
+
+
+class MutationDatabase(object):
+    """
+    A persistent key-value store backed by SQLite.
+
+    This replaces the previous ``shelve``-based storage. ``shelve`` relies on
+    the platform's ``dbm`` backend, so the resulting database file format
+    differs between operating systems and Python builds and cannot be moved
+    between them. SQLite produces a single, self-contained, cross-platform file
+    instead.
+
+    Keys are strings (relative file paths). Values are arbitrary picklable
+    Python objects (for example a list of mutant file paths, or a tuple of the
+    survived and killed mutant lists).
+    """
+
+    def __init__(self, databasePath, flag="c"):
+        """
+        Opens (or creates) the database.
+
+        :param databasePath: Path to the SQLite database file.
+        :type databasePath: str
+        :param flag: Open mode, mirroring ``shelve``/``dbm`` semantics:
+                     ``"r"`` read-only (the file must already exist),
+                     ``"c"`` open for read/write, creating the file if needed,
+                     ``"n"`` always create a new, empty database.
+        :type flag: str
+        """
+        self.databasePath = databasePath
+
+        if flag == "n" and os.path.exists(databasePath):
+            os.remove(databasePath)
+
+        if flag == "r" and not os.path.exists(databasePath):
+            raise FileNotFoundError("Database does not exist: " + str(databasePath))
+
+        self.connection = sqlite3.connect(databasePath)
+        self.connection.execute(
+            "CREATE TABLE IF NOT EXISTS entries (key TEXT PRIMARY KEY, value BLOB)")
+        self.connection.commit()
+
+    def set(self, key, value):
+        """
+        Stores ``value`` under ``key``, overwriting any existing entry.
+
+        :param key: The entry key.
+        :type key: str
+        :param value: Any picklable Python object.
+        """
+        blob = sqlite3.Binary(pickle.dumps(value, protocol=pickle.HIGHEST_PROTOCOL))
+        self.connection.execute(
+            "INSERT OR REPLACE INTO entries (key, value) VALUES (?, ?)", (key, blob))
+        self.connection.commit()
+
+    def get(self, key):
+        """
+        Returns the value stored under ``key``.
+
+        :param key: The entry key.
+        :type key: str
+        :return: The previously stored Python object.
+        :raises KeyError: if the key is not present (mirrors ``db[key]``).
+        """
+        row = self.connection.execute(
+            "SELECT value FROM entries WHERE key = ?", (key,)).fetchone()
+        if row is None:
+            raise KeyError(key)
+        return pickle.loads(row[0])
+
+    def keys(self):
+        """
+        Returns the list of all keys in the database.
+
+        :rtype: list
+        """
+        return [row[0] for row in self.connection.execute("SELECT key FROM entries")]
+
+    def __contains__(self, key):
+        return self.connection.execute(
+            "SELECT 1 FROM entries WHERE key = ?", (key,)).fetchone() is not None
+
+    def __len__(self):
+        return self.connection.execute("SELECT COUNT(*) FROM entries").fetchone()[0]
+
+    def close(self):
+        """
+        Commits any pending changes and closes the underlying connection.
+        """
+        if self.connection is not None:
+            self.connection.commit()
+            self.connection.close()
+            self.connection = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, excType, excValue, traceback):
+        self.close()

--- a/littledarwin/MutationDatabase.py
+++ b/littledarwin/MutationDatabase.py
@@ -1,21 +1,35 @@
 import os
-import pickle
 import sqlite3
+
+
+_VALID_STATUSES = ("pending", "survived", "killed")
 
 
 class MutationDatabase(object):
     """
-    A persistent key-value store backed by SQLite.
+    Relational SQLite store for a LittleDarwin run.
 
-    This replaces the previous ``shelve``-based storage. ``shelve`` relies on
-    the platform's ``dbm`` backend, so the resulting database file format
-    differs between operating systems and Python builds and cannot be moved
-    between them. SQLite produces a single, self-contained, cross-platform file
-    instead.
+    Earlier versions used ``shelve`` (cross-platform incompatible) and then a
+    pickle-BLOB SQLite store. This version persists the same information in a
+    normalized relational schema so anyone — a SQL client, a downstream tool,
+    a future LittleDarwin feature — can query it directly without unpickling.
 
-    Keys are strings (relative file paths). Values are arbitrary picklable
-    Python objects (for example a list of mutant file paths, or a tuple of the
-    survived and killed mutant lists).
+    Schema (five tables, one SQLite file per run):
+
+    * ``source_files(id, path)`` — one row per mutated Java source file.
+      ``path`` is the source-relative path (e.g. ``com/example/Foo.java``).
+    * ``mutants(id, source_file_id, mutant_index, mutant_path, build_status)``
+      — one row per generated mutant file. ``mutant_index`` is the ``N`` in
+      ``N.java``; ``mutant_path`` is the relative path under the mutants
+      directory; ``build_status`` is one of ``pending`` (after mutation phase),
+      ``survived``, or ``killed`` (after build phase).
+    * ``mutant_density_per_line(source_file_id, line_number, mutant_count)``
+      — same data that's also dumped to ``MutantDensityPerLine.csv``.
+    * ``complexity_per_method(source_file_id, method_name, density,
+      cyclomatic, lines_of_code)`` — same data as ``ComplexityPerMethod.csv``.
+
+    Mutation databases are regenerated each run; there is no backward
+    compatibility with older shelve or pickle-BLOB databases.
     """
 
     def __init__(self, databasePath, flag="c"):
@@ -39,52 +53,167 @@ class MutationDatabase(object):
             raise FileNotFoundError("Database does not exist: " + str(databasePath))
 
         self.connection = sqlite3.connect(databasePath)
-        self.connection.execute(
-            "CREATE TABLE IF NOT EXISTS entries (key TEXT PRIMARY KEY, value BLOB)")
+        self.connection.execute("PRAGMA foreign_keys = ON")
+        self._createSchema()
+
+    def _createSchema(self):
+        cursor = self.connection.cursor()
+        cursor.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS source_files (
+                id   INTEGER PRIMARY KEY,
+                path TEXT NOT NULL UNIQUE
+            );
+
+            CREATE TABLE IF NOT EXISTS mutants (
+                id             INTEGER PRIMARY KEY,
+                source_file_id INTEGER NOT NULL REFERENCES source_files(id) ON DELETE CASCADE,
+                mutant_index   INTEGER NOT NULL,
+                mutant_path    TEXT NOT NULL UNIQUE,
+                build_status   TEXT NOT NULL DEFAULT 'pending'
+                               CHECK (build_status IN ('pending','survived','killed')),
+                UNIQUE (source_file_id, mutant_index)
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_mutants_source ON mutants(source_file_id);
+            CREATE INDEX IF NOT EXISTS idx_mutants_status ON mutants(build_status);
+
+            CREATE TABLE IF NOT EXISTS mutant_density_per_line (
+                source_file_id INTEGER NOT NULL REFERENCES source_files(id) ON DELETE CASCADE,
+                line_number    INTEGER NOT NULL,
+                mutant_count   INTEGER NOT NULL,
+                PRIMARY KEY (source_file_id, line_number)
+            );
+
+            CREATE TABLE IF NOT EXISTS complexity_per_method (
+                source_file_id INTEGER NOT NULL REFERENCES source_files(id) ON DELETE CASCADE,
+                method_name    TEXT NOT NULL,
+                density        INTEGER NOT NULL,
+                cyclomatic     INTEGER NOT NULL,
+                lines_of_code  INTEGER NOT NULL,
+                PRIMARY KEY (source_file_id, method_name)
+            );
+            """
+        )
         self.connection.commit()
 
-    def set(self, key, value):
+    def add_source_file(self, source_path):
         """
-        Stores ``value`` under ``key``, overwriting any existing entry.
+        Idempotently inserts a source file and returns its row id.
+        """
+        cursor = self.connection.cursor()
+        cursor.execute(
+            "INSERT OR IGNORE INTO source_files (path) VALUES (?)", (source_path,))
+        cursor.execute(
+            "SELECT id FROM source_files WHERE path = ?", (source_path,))
+        row = cursor.fetchone()
+        self.connection.commit()
+        return row[0]
 
-        :param key: The entry key.
-        :type key: str
-        :param value: Any picklable Python object.
+    def add_mutant(self, source_path, mutant_index, mutant_path):
         """
-        blob = sqlite3.Binary(pickle.dumps(value, protocol=pickle.HIGHEST_PROTOCOL))
+        Inserts a mutant row for ``source_path`` with ``build_status='pending'``.
+        Upserts the parent source_files row first.
+        """
+        source_id = self.add_source_file(source_path)
         self.connection.execute(
-            "INSERT OR REPLACE INTO entries (key, value) VALUES (?, ?)", (key, blob))
+            "INSERT INTO mutants (source_file_id, mutant_index, mutant_path) VALUES (?, ?, ?)",
+            (source_id, int(mutant_index), mutant_path))
         self.connection.commit()
 
-    def get(self, key):
+    def record_result(self, mutant_path, status):
         """
-        Returns the value stored under ``key``.
+        Flips ``mutant_path``'s ``build_status`` to ``status`` (``'survived'``
+        or ``'killed'``). Re-recording overwrites the previous value.
+        """
+        if status not in ("survived", "killed"):
+            raise ValueError("status must be 'survived' or 'killed', got: " + repr(status))
+        cursor = self.connection.execute(
+            "UPDATE mutants SET build_status = ? WHERE mutant_path = ?",
+            (status, mutant_path))
+        if cursor.rowcount == 0:
+            raise KeyError(mutant_path)
+        self.connection.commit()
 
-        :param key: The entry key.
-        :type key: str
-        :return: The previously stored Python object.
-        :raises KeyError: if the key is not present (mirrors ``db[key]``).
+    def record_line_densities(self, source_path, densities):
+        """
+        Replaces the per-line mutant counts for ``source_path``.
+
+        :param densities: Iterable of ``(line_number, mutant_count)`` pairs.
+        """
+        source_id = self.add_source_file(source_path)
+        rows = [(source_id, int(line), int(count)) for line, count in densities]
+        self.connection.execute(
+            "DELETE FROM mutant_density_per_line WHERE source_file_id = ?", (source_id,))
+        self.connection.executemany(
+            "INSERT INTO mutant_density_per_line (source_file_id, line_number, mutant_count) VALUES (?, ?, ?)",
+            rows)
+        self.connection.commit()
+
+    def record_method_complexities(self, source_path, complexities):
+        """
+        Replaces the per-method complexity rows for ``source_path``.
+
+        :param complexities: Iterable of
+            ``(method_name, density, cyclomatic, lines_of_code)`` tuples.
+        """
+        source_id = self.add_source_file(source_path)
+        rows = [(source_id, name, int(density), int(cyclomatic), int(loc))
+                for name, density, cyclomatic, loc in complexities]
+        self.connection.execute(
+            "DELETE FROM complexity_per_method WHERE source_file_id = ?", (source_id,))
+        self.connection.executemany(
+            "INSERT INTO complexity_per_method "
+            "(source_file_id, method_name, density, cyclomatic, lines_of_code) "
+            "VALUES (?, ?, ?, ?, ?)",
+            rows)
+        self.connection.commit()
+
+    def source_paths(self):
+        """
+        Returns the list of source-file paths that have at least one mutant.
+        """
+        return [row[0] for row in self.connection.execute(
+            "SELECT s.path FROM source_files s "
+            "WHERE EXISTS (SELECT 1 FROM mutants m WHERE m.source_file_id = s.id)")]
+
+    def mutants_for(self, source_path):
+        """
+        Returns the mutant relative paths for ``source_path``, ordered by
+        mutant_index. Empty list if the source is unknown or has no mutants.
+        """
+        return [row[0] for row in self.connection.execute(
+            "SELECT m.mutant_path FROM mutants m "
+            "JOIN source_files s ON s.id = m.source_file_id "
+            "WHERE s.path = ? ORDER BY m.mutant_index", (source_path,))]
+
+    def mutant_count_for(self, source_path):
+        """
+        Returns the number of mutants registered for ``source_path``.
         """
         row = self.connection.execute(
-            "SELECT value FROM entries WHERE key = ?", (key,)).fetchone()
-        if row is None:
-            raise KeyError(key)
-        return pickle.loads(row[0])
+            "SELECT COUNT(*) FROM mutants m "
+            "JOIN source_files s ON s.id = m.source_file_id "
+            "WHERE s.path = ?", (source_path,)).fetchone()
+        return row[0]
 
-    def keys(self):
+    def results_for(self, source_path):
         """
-        Returns the list of all keys in the database.
-
-        :rtype: list
+        Returns ``(survived_basenames, killed_basenames)`` for ``source_path``,
+        each list ordered by mutant_index. Pending mutants are excluded.
         """
-        return [row[0] for row in self.connection.execute("SELECT key FROM entries")]
-
-    def __contains__(self, key):
-        return self.connection.execute(
-            "SELECT 1 FROM entries WHERE key = ?", (key,)).fetchone() is not None
-
-    def __len__(self):
-        return self.connection.execute("SELECT COUNT(*) FROM entries").fetchone()[0]
+        rows = self.connection.execute(
+            "SELECT m.mutant_path, m.build_status FROM mutants m "
+            "JOIN source_files s ON s.id = m.source_file_id "
+            "WHERE s.path = ? ORDER BY m.mutant_index", (source_path,))
+        survived = []
+        killed = []
+        for mutant_path, status in rows:
+            if status == "survived":
+                survived.append(os.path.basename(mutant_path))
+            elif status == "killed":
+                killed.append(os.path.basename(mutant_path))
+        return survived, killed
 
     def close(self):
         """

--- a/littledarwin/ReportGenerator.py
+++ b/littledarwin/ReportGenerator.py
@@ -1,7 +1,5 @@
 import os
 
-from .MutationDatabase import MutationDatabase
-
 
 class ReportGenerator(object):
     """
@@ -16,17 +14,7 @@ class ReportGenerator(object):
         :param littleDarwinVersion: The version of LittleDarwin.
         :type littleDarwinVersion: str
         """
-        self.database = None
         self.ldVersion = littleDarwinVersion
-
-    def initiateDatabase(self, databasePath):
-        """
-        Initiates the results database.
-
-        :param databasePath: The path to the results database.
-        :type databasePath: str
-        """
-        self.database = MutationDatabase(databasePath, "c")
 
     def generateHTMLFinalReport(self, resultData, reportPath):
         """
@@ -122,8 +110,6 @@ class ReportGenerator(object):
                 return ''
             else:
                 return str(inputVar)
-
-        self.database.set(filePath, (survived, killed))
 
         reportBeginning = """<!DOCTYPE html><html><head><title>LittleDarwin Mutation Coverage Report</title>
              <style type='text/css'> body { font-family: "Carlito", "Calibri", "Helvetica Neue", sans-serif; } 

--- a/littledarwin/ReportGenerator.py
+++ b/littledarwin/ReportGenerator.py
@@ -1,5 +1,6 @@
 import os
-import shelve
+
+from .MutationDatabase import MutationDatabase
 
 
 class ReportGenerator(object):
@@ -25,7 +26,7 @@ class ReportGenerator(object):
         :param databasePath: The path to the results database.
         :type databasePath: str
         """
-        self.database = shelve.open(databasePath, "c")
+        self.database = MutationDatabase(databasePath, "c")
 
     def generateHTMLFinalReport(self, resultData, reportPath):
         """
@@ -122,7 +123,7 @@ class ReportGenerator(object):
             else:
                 return str(inputVar)
 
-        self.database[filePath] = (survived, killed)
+        self.database.set(filePath, (survived, killed))
 
         reportBeginning = """<!DOCTYPE html><html><head><title>LittleDarwin Mutation Coverage Report</title>
              <style type='text/css'> body { font-family: "Carlito", "Calibri", "Helvetica Neue", sans-serif; } 

--- a/tests/test_MutationDatabase.py
+++ b/tests/test_MutationDatabase.py
@@ -1,0 +1,139 @@
+import os
+import sqlite3
+import tempfile
+import unittest
+
+from littledarwin.MutationDatabase import MutationDatabase
+
+
+class TestMutationDatabase(unittest.TestCase):
+
+    def setUp(self):
+        self.tempDir = tempfile.TemporaryDirectory()
+        self.dbPath = os.path.join(self.tempDir.name, "mutationdatabase")
+
+    def tearDown(self):
+        self.tempDir.cleanup()
+
+    def test_roundtrip_source_files_and_mutants(self):
+        with MutationDatabase(self.dbPath, "n") as db:
+            db.add_mutant("com/example/Foo.java", 1, "com/example/Foo.java/1.java")
+            db.add_mutant("com/example/Foo.java", 2, "com/example/Foo.java/2.java")
+            db.add_mutant("com/example/Bar.java", 1, "com/example/Bar.java/1.java")
+
+        with MutationDatabase(self.dbPath, "r") as db:
+            self.assertEqual(sorted(db.source_paths()),
+                             ["com/example/Bar.java", "com/example/Foo.java"])
+            self.assertEqual(db.mutants_for("com/example/Foo.java"),
+                             ["com/example/Foo.java/1.java", "com/example/Foo.java/2.java"])
+            self.assertEqual(db.mutant_count_for("com/example/Foo.java"), 2)
+            self.assertEqual(db.mutant_count_for("com/example/Bar.java"), 1)
+            self.assertEqual(db.mutant_count_for("com/example/Nobody.java"), 0)
+            self.assertEqual(db.mutants_for("com/example/Nobody.java"), [])
+
+    def test_mutants_for_is_ordered_by_index(self):
+        with MutationDatabase(self.dbPath, "n") as db:
+            db.add_mutant("Foo.java", 3, "Foo.java/3.java")
+            db.add_mutant("Foo.java", 1, "Foo.java/1.java")
+            db.add_mutant("Foo.java", 2, "Foo.java/2.java")
+            self.assertEqual(
+                db.mutants_for("Foo.java"),
+                ["Foo.java/1.java", "Foo.java/2.java", "Foo.java/3.java"])
+
+    def test_record_result_flips_status_and_results_for_partitions(self):
+        with MutationDatabase(self.dbPath, "n") as db:
+            db.add_mutant("Foo.java", 1, "Foo.java/1.java")
+            db.add_mutant("Foo.java", 2, "Foo.java/2.java")
+            db.add_mutant("Foo.java", 3, "Foo.java/3.java")
+
+            survived, killed = db.results_for("Foo.java")
+            self.assertEqual((survived, killed), ([], []))
+
+            db.record_result("Foo.java/1.java", "survived")
+            db.record_result("Foo.java/2.java", "killed")
+            db.record_result("Foo.java/3.java", "killed")
+
+            survived, killed = db.results_for("Foo.java")
+            self.assertEqual(survived, ["1.java"])
+            self.assertEqual(killed, ["2.java", "3.java"])
+
+            db.record_result("Foo.java/1.java", "killed")
+            survived, killed = db.results_for("Foo.java")
+            self.assertEqual(survived, [])
+            self.assertEqual(killed, ["1.java", "2.java", "3.java"])
+
+    def test_record_result_rejects_unknown_status(self):
+        with MutationDatabase(self.dbPath, "n") as db:
+            db.add_mutant("Foo.java", 1, "Foo.java/1.java")
+            with self.assertRaises(ValueError):
+                db.record_result("Foo.java/1.java", "pending")
+            with self.assertRaises(ValueError):
+                db.record_result("Foo.java/1.java", "anything-else")
+
+    def test_record_result_unknown_mutant_raises_keyerror(self):
+        with MutationDatabase(self.dbPath, "n") as db:
+            with self.assertRaises(KeyError):
+                db.record_result("does/not/exist.java/1.java", "killed")
+
+    def test_unique_constraints_block_duplicates(self):
+        with MutationDatabase(self.dbPath, "n") as db:
+            db.add_mutant("Foo.java", 1, "Foo.java/1.java")
+            with self.assertRaises(sqlite3.IntegrityError):
+                db.add_mutant("Foo.java", 1, "Foo.java/1.java")
+            with self.assertRaises(sqlite3.IntegrityError):
+                db.add_mutant("Other.java", 1, "Foo.java/1.java")
+
+    def test_density_and_complexity_roundtrip(self):
+        with MutationDatabase(self.dbPath, "n") as db:
+            db.record_line_densities("Foo.java", [(5, 2), (10, 1), (15, 3)])
+            db.record_method_complexities(
+                "Foo.java",
+                [("myMethod", 4, 3, 12), ("other", 1, 2, 8)])
+
+            conn = sqlite3.connect(self.dbPath)
+            try:
+                density_rows = conn.execute(
+                    "SELECT line_number, mutant_count FROM mutant_density_per_line "
+                    "JOIN source_files ON source_files.id = source_file_id "
+                    "WHERE path = 'Foo.java' ORDER BY line_number").fetchall()
+                complexity_rows = conn.execute(
+                    "SELECT method_name, density, cyclomatic, lines_of_code "
+                    "FROM complexity_per_method "
+                    "JOIN source_files ON source_files.id = source_file_id "
+                    "WHERE path = 'Foo.java' ORDER BY method_name").fetchall()
+            finally:
+                conn.close()
+
+            self.assertEqual(density_rows, [(5, 2), (10, 1), (15, 3)])
+            self.assertEqual(complexity_rows,
+                             [("myMethod", 4, 3, 12), ("other", 1, 2, 8)])
+
+    def test_density_record_replaces_previous(self):
+        with MutationDatabase(self.dbPath, "n") as db:
+            db.record_line_densities("Foo.java", [(1, 1), (2, 2)])
+            db.record_line_densities("Foo.java", [(3, 3)])
+
+            conn = sqlite3.connect(self.dbPath)
+            try:
+                rows = conn.execute(
+                    "SELECT line_number, mutant_count FROM mutant_density_per_line "
+                    "JOIN source_files ON source_files.id = source_file_id "
+                    "WHERE path = 'Foo.java'").fetchall()
+            finally:
+                conn.close()
+            self.assertEqual(rows, [(3, 3)])
+
+    def test_read_only_open_missing_file_raises(self):
+        with self.assertRaises(FileNotFoundError):
+            MutationDatabase(self.dbPath, "r")
+
+    def test_n_flag_wipes_existing_file(self):
+        with MutationDatabase(self.dbPath, "n") as db:
+            db.add_mutant("Foo.java", 1, "Foo.java/1.java")
+        with MutationDatabase(self.dbPath, "n") as db:
+            self.assertEqual(db.source_paths(), [])
+            self.assertEqual(db.mutants_for("Foo.java"), [])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Migrates LittleDarwin's mutation/results storage off `shelve` and ultimately onto a **relational SQLite schema**. The first commit on this branch swapped `shelve` for SQLite while keeping dict-of-pickles semantics; the second commit drops pickle entirely and normalizes everything into a five-table relational schema so the run produces a self-contained, queryable artifact.

`shelve` relied on the platform `dbm` backend, so the on-disk format differed across operating systems and Python builds — generate on Linux, build on Windows, hit *"Cannot open mutation database."* SQLite is a single, self-contained, cross-platform file in the standard library (no new dependencies). The relational schema removes the remaining opacity: anyone can `SELECT COUNT(*) FROM mutants WHERE build_status='killed'` without unpickling.

## Schema

```sql
CREATE TABLE source_files (
    id   INTEGER PRIMARY KEY,
    path TEXT NOT NULL UNIQUE
);

CREATE TABLE mutants (
    id             INTEGER PRIMARY KEY,
    source_file_id INTEGER NOT NULL REFERENCES source_files(id) ON DELETE CASCADE,
    mutant_index   INTEGER NOT NULL,
    mutant_path    TEXT NOT NULL UNIQUE,
    build_status   TEXT NOT NULL DEFAULT 'pending'
                   CHECK (build_status IN ('pending','survived','killed')),
    UNIQUE (source_file_id, mutant_index)
);

CREATE TABLE mutant_density_per_line (
    source_file_id INTEGER NOT NULL REFERENCES source_files(id) ON DELETE CASCADE,
    line_number    INTEGER NOT NULL,
    mutant_count   INTEGER NOT NULL,
    PRIMARY KEY (source_file_id, line_number)
);

CREATE TABLE complexity_per_method (
    source_file_id INTEGER NOT NULL REFERENCES source_files(id) ON DELETE CASCADE,
    method_name    TEXT NOT NULL,
    density        INTEGER NOT NULL,
    cyclomatic     INTEGER NOT NULL,
    lines_of_code  INTEGER NOT NULL,
    PRIMARY KEY (source_file_id, method_name)
);
```

Plus indexes on `mutants(source_file_id)` and `mutants(build_status)`.

## Changes

- **`littledarwin/MutationDatabase.py`** — relational store with typed methods (`add_source_file`, `add_mutant`, `record_result`, `record_line_densities`, `record_method_complexities`, `source_paths`, `mutants_for`, `mutant_count_for`, `results_for`). The old `set`/`get` dict-style API is gone. `import pickle` is gone.
- **`littledarwin/LittleDarwin.py`** — `mutationPhase` calls `add_mutant` inside the existing mutant loop (no in-memory `targetList`) and feeds the per-file density/complexity into the DB alongside the existing CSV side-cars. `buildPhase` uses `mutants_for` and updates each mutant's `build_status` via `record_result` instead of writing a separate results database.
- **`littledarwin/ReportGenerator.py`** — no longer owns its own DB file; the per-file HTML still gets `survived`/`killed` lists passed in.
- **`docs/source/usage.rst`** — `--use-alternate-database` wording tightened to point at the relational schema.
- **`tests/test_MutationDatabase.py`** — 10 new unit tests covering round-trips, status transitions, CHECK / UNIQUE constraints, read-only-open-missing-file, and "n"-flag wiping.

The mutation and results databases are now consolidated into a single SQLite file (`mutationdatabase`); the previous `mutationdatabase-results` file is gone. No backward compatibility with older shelve or pickle-BLOB databases — mutation DBs are regenerated each run.

## Scope kept out

- `ProjectDensityReport.csv` (project-wide mutator counts) — still CSV-only; trivial to add later as a `mutator_counts` table if needed.
- Per-mutant attribution to operator/line/method on the `mutants` row itself — possible but requires plumbing changes inside `JavaMutate`; left for a future pass.
- The per-file `MutantDensityPerLine.csv` and `ComplexityPerMethod.csv` side-cars continue to be written for external-tooling compatibility; the DB just mirrors that data.

## Testing

- Full pytest suite: **52 passed in 269.34s** (42 prior + 10 new `MutationDatabase` unit tests), including the end-to-end Maven `test_VideoStoreTraditionalBuild`.
- Manual DB inspection on the VideoStore fixture confirms `SELECT ... FROM mutants` totals (44 mutants, 42 killed, 2 survived) match the generated HTML report, and that the `mutant_density_per_line` / `complexity_per_method` rows match the corresponding side-car CSVs byte-for-byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)